### PR TITLE
Update INSERT statement

### DIFF
--- a/lib/fluent/plugin/out_timescaledb.rb
+++ b/lib/fluent/plugin/out_timescaledb.rb
@@ -27,7 +27,7 @@ module Fluent
           values << "('#{@conn.escape_string(format_time(time))}','#{@conn.escape_string(tag)}','#{@conn.escape_string(record.to_json)}'::jsonb)"
         end
 
-        @conn.exec("INSERT INTO #{@conn.escape_identifier(@db_table_name)} (time, tag, record) VALUES #{values.join(',')}")
+        @conn.exec("INSERT INTO #{@db_table_name} (time, tag, record) VALUES #{values.join(',')}")
       end
 
       def format(tag, time, record)


### PR DESCRIPTION
This prevents errors due to extra backslash
```
2019-12-34 01:02:03 +0000 [warn]: #0 fluent/log.rb:342:warn: failed to flush the buffer. 
retry_time=1 next_retry_seconds=2019-12-06 01:32:35 +0000 chunk="...." error_class=PG::UndefinedTable 
error="ERROR:  relation \"schema.table\" does not exist\n
LINE 1: INSERT INTO \"schema.table\" (time, tag, record) VALUES...\n
                    ^\n"
```