### PR TITLE
Enable sub second data support in timestamps

### DIFF
--- a/lib/fluent/plugin/out_timescaledb.rb
+++ b/lib/fluent/plugin/out_timescaledb.rb
@@ -31,7 +31,7 @@ module Fluent
       end
 
       def format(tag, time, record)
-        [tag, time, record].to_msgpack
+        [tag, time.to_f, record].to_msgpack
       end
 
       def formatted_to_msgpack_binary


### PR DESCRIPTION
The default `to_msgpack` method of `EventTime` will cast the time into an Integer, losing all sub second data: https://github.com/fluent/fluentd/blob/af001b76a20d6f7d71f50057f51a01c5ab3bd936/lib/fluent/time.rb#L90
Calling `to_f` will convert the `EventTime` into a float before serializing a msgpack, which will allow for sub second timestamps to be stored in the logs.

I'm not sure if this is the best solution though, I'm not a Ruby developer.